### PR TITLE
Export path

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -154,5 +154,6 @@ conan_staticlibs="{staticlibs}"
             self.cpp_info.libs.append("m")
         self.cpp_info.includedirs.append(os.path.join("include", "freetype2"))
         freetype_config = os.path.join(self.package_folder, "bin", "freetype-config")
+        self.env_info.PATH.append(os.path.join(self.package_folder, "bin"))
         self.env_info.FT2_CONFIG = freetype_config
         self._chmod_plus_x(freetype_config)


### PR DESCRIPTION
Export the package `bin` dir path to allow `freetype-config` to be found.